### PR TITLE
Bump nategood/httpful to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^8.2",
         "symfony/console": "^6.4|^7.0",
-        "nategood/httpful": "^0.3.2",
+        "nategood/httpful": "^1.0",
         "webmozart/assert": "^1.11",
         "symfony/process": "^6.4|^7.0"
     },

--- a/src/GitResolver.php
+++ b/src/GitResolver.php
@@ -6,6 +6,7 @@ namespace Rector\ReleaseNotesGenerator;
 
 use Rector\ReleaseNotesGenerator\ValueObject\Commit;
 use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
 
 final class GitResolver
 {
@@ -34,6 +35,11 @@ final class GitResolver
     {
         return array_map(static function (string $line): Commit {
             preg_match('#(?<hash>\w+) (?<message>.*?) (?<date>\d+\-\d+\-\d+)#', $line, $matches);
+
+            Assert::keyExists($matches, 'hash');
+            Assert::keyExists($matches, 'message');
+            Assert::keyExists($matches, 'date');
+
             return new Commit($matches['hash'], $matches['message'], $matches['date']);
         }, $commitLines);
     }


### PR DESCRIPTION
Fix security advisory reported on usage in rector-src:

```
➜  rector-src git:(main) ✗ composer audit
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | nategood/httpful                                                                 |
| Severity          | medium                                                                           |
| CVE               | NO CVE                                                                           |
| Title             | Insecure HTTPS Connections due to Missing Default Certificate Validation         |
| URL               | https://huntr.com/bounties/8d59c089-92f1-4b73-90f8-54968a70e2fb                  |
| Affected versions | <0.2.0|>=0.2.0,<0.3.0|>=0.3.0,<1.0.0                                             |
| Reported at       | 2024-05-01T00:00:00+00:00                                                        |
| Advisory ID       | PKSA-4dtf-ym9h-t41j                                                              |
+-------------------+----------------------------------------------------------------------------------+
➜  rector-src git:(main) ✗ composer why nategood/httpful
rector/release-notes-generator 0.2.0 requires nategood/httpful (^0.3.2) 
```